### PR TITLE
[Discussion] Adding Visual Studio Live Share

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "johnpapa.azure-functions-tools",
         "kisstkondoros.vscode-codemetrics",
         "msjsdiag.debugger-for-chrome",
-        "wix.vscode-import-cost"
+        "wix.vscode-import-cost",
+        "MS-vsliveshare.vsliveshare"
     ]
 }


### PR DESCRIPTION
This PR simply proposes adding the [Visual Studio Live Share](aka.ms/vsls) extension to this extension pack, since it has been highly optimized for Node.js collaborative development/remote pair programming. 

It’s currently in preview, however, anyone with the extension installed can join collaboration sessions, so it’s already broadly applicable to Node.js devs. 

// CC @bnb 