### PR TITLE
Use `extensionPack` instead of `extensionDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.3.1",
     "publisher": "nodesource",
     "engines": {
-        "vscode": "^1.12.0"
+        "vscode": "^1.26.0"
     },
     "categories": [
         "Extension Packs"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "type": "git",
         "url": "https://github.com/nodesource/vs-code-for-node-js-development-pack.git"
     },
-    "extensionDependencies": [
+    "extensionPack": [
         "PeterJausovec.vscode-docker",
         "Shan.code-settings-sync",
         "christian-kohler.npm-intellisense",


### PR DESCRIPTION
From release v1.26, defining an Extension Pack now uses a new property called `extensionPack` instead of `extensionDependencies` in package.json. This is because extensionDependencies is mainly used to define functional dependencies and an Extension Pack should not have any functional dependencies with its bundled extensions and they should be manageable independent of the pack. 

So please use `extensionPack` property for defining the pack.

For more details refer to [Release notes](https://code.visualstudio.com/updates/v1_26#_extension-packs-revisited)